### PR TITLE
fix log_silently config

### DIFF
--- a/lib/neo-asset_sync/asset_sync.rb
+++ b/lib/neo-asset_sync/asset_sync.rb
@@ -57,7 +57,7 @@ module AssetSync
     end
 
     def log(msg)
-      stdout.puts msg if config.log_silently?
+      stdout.puts msg unless config.log_silently?
     end
 
     def enabled?

--- a/lib/neo-asset_sync/config.rb
+++ b/lib/neo-asset_sync/config.rb
@@ -94,7 +94,7 @@ module AssetSync
     end
 
     def log_silently?
-      ENV['RAILS_GROUPS'] == 'assets' || self.log_silently == false
+      ENV['RAILS_GROUPS'] == 'assets' || !!self.log_silently
     end
 
     def enabled?

--- a/spec/unit/asset_sync_spec.rb
+++ b/spec/unit/asset_sync_spec.rb
@@ -65,6 +65,17 @@ describe AssetSync do
     it "should default log_silently to true" do
       expect(AssetSync.config.log_silently).to be_truthy
     end
+    
+    it "log_silently? should reflect the configuration" do
+      AssetSync.config.log_silently = false
+      expect(AssetSync.config.log_silently?).to eq(false)
+    end
+
+    it "log_silently? should always be true if ENV['RAILS_GROUPS'] == 'assets'" do
+      AssetSync.config.log_silently = false
+      expect(ENV).to receive(:[]).with('RAILS_GROUPS').and_return('assets')
+      expect(AssetSync.config.log_silently?).to eq(true)
+    end
 
     it "should default cdn_distribution_id to nil" do
       expect(AssetSync.config.cdn_distribution_id).to be_nil


### PR DESCRIPTION
The logic for `log_silently?` was broken, and now it is fixed. 
